### PR TITLE
[CAL-34961] Adds event-type route and view

### DIFF
--- a/components/app.jsx
+++ b/components/app.jsx
@@ -36,6 +36,7 @@ let App = () => (
         <EventType />
       </RequireAuth>
     }
+    />
     <Route path="/events/:uuid"
       element={
         <RequireAuth>

--- a/components/app.jsx
+++ b/components/app.jsx
@@ -1,5 +1,6 @@
 import Dashboard from './dashboard.jsx';
 import Events from './events.jsx';
+import EventType from './eventType';
 import Login from './login.jsx';
 import Nav from './nav.jsx';
 import React from 'react';
@@ -26,6 +27,14 @@ let App = () => (
           <Events />
         </RequireAuth>
       }
+    />
+    <Route
+    path="/event_types/:uuid"
+    element={
+      <RequireAuth>
+        <EventType />
+      </RequireAuth>
+    }
     />
   </Routes>
 );

--- a/components/dashboard.jsx
+++ b/components/dashboard.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { PopupButton } from 'react-calendly';
+import { Link } from 'react-router-dom'
 
 export default () => {
   const [eventTypes, setEventTypes] = useState([]);
@@ -17,6 +18,7 @@ export default () => {
       <div className="row">
         {eventTypes.map((eventType) => (
           <div className="col s6" key={eventType.uri}>
+             <Link to={`/event_types/${eventType.uri.split('/')[4]}`}>
             <div className="card">
               <div
                 style={{
@@ -25,9 +27,9 @@ export default () => {
                   width: '100%',
                 }}
               ></div>
-              <div className="card-content">
+              <div className="card-content" style={{ color: 'black'}}>
                 <p>{eventType.name}</p>
-                <p>{eventType.description_plain}</p>
+                <p style={{ fontSize: 'small' }}>Description: {eventType.description_plain || 'No description'}</p>
               </div>
               <div className="card-action">
                 <PopupButton
@@ -42,6 +44,7 @@ export default () => {
                 />
               </div>
             </div>
+            </Link>
           </div>
         ))}
       </div>

--- a/components/eventType.jsx
+++ b/components/eventType.jsx
@@ -14,15 +14,21 @@ export default () => {
 
         setEventType(result.event)
     }
+
+    console.log(eventType)
     useEffect(() => {
         fetchData()
     }, []);
 
     return (
-        <div style={{ textAlign: 'center' }}>
-            <p>{`Last updated ${eventType.last_updated}`}</p>
-            <p>{eventType.name}</p>
-            <p>***This page will allow user to edit the event type***</p>
+        <div>
+            <p style={{ textAlign: 'center' }}>{`Last updated ${eventType.last_updated}`}</p>
+            <h5>{eventType.name}</h5>
+            <div><strong>Invitee Questions: </strong>{eventType.custom_questions && eventType.custom_questions.map((question) => (
+                // It doesn't increment correctly with an ol, so I've done it this way (below) to create a numbered list.
+                <p key={question.position}>{`${question.position + 1}. ${question.name}`}</p>))}
+            </div>
+            <p><strong>Duration: </strong>{`${eventType.duration} minutes`}</p>
         </div>
     )
 }

--- a/components/eventType.jsx
+++ b/components/eventType.jsx
@@ -1,0 +1,28 @@
+import React, { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+
+export default () => {
+
+    const [eventType, setEventType] = useState([]);
+
+    const { uuid } = useParams();
+
+    const fetchData = async () => {
+        const result = await fetch(
+            `/api/event_types/${uuid}`
+        ).then((res) => res.json());
+
+        setEventType(result.event)
+    }
+    useEffect(() => {
+        fetchData()
+    }, []);
+
+    return (
+        <div style={{ textAlign: 'center' }}>
+            <p>{`Last updated ${eventType.last_updated}`}</p>
+            <p>{eventType.name}</p>
+            <p>***This page will allow user to edit the event type***</p>
+        </div>
+    )
+}

--- a/components/eventType.jsx
+++ b/components/eventType.jsx
@@ -12,10 +12,9 @@ export default () => {
             `/api/event_types/${uuid}`
         ).then((res) => res.json());
 
-        setEventType(result.event)
+        setEventType(result.eventType)
     }
 
-    console.log(eventType)
     useEffect(() => {
         fetchData()
     }, []);

--- a/routes/api.js
+++ b/routes/api.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const CalendlyService = require('../services/calendlyService');
-const { isUserAuthenticated, formatEventDateTime } = require('../utils');
+const { isUserAuthenticated, formatEventDateTime, formatEventTypeDate } = require('../utils');
 const router = express.Router();
 const User = require('../models/userModel');
 
@@ -27,6 +27,16 @@ router
       await calendlyService.getUserEventTypes(calendly_uid);
 
     res.json({ eventTypes, pagination });
+  })
+  .get('/event_types/:uuid', isUserAuthenticated, async (req, res) => {
+    const { access_token, refresh_token } = req.user;
+    const calendlyService = new CalendlyService(access_token, refresh_token);
+    const { uuid } = req.params;
+    const { resource } = await calendlyService.getUserEventType(uuid);
+
+    const event = formatEventTypeDate(resource)
+
+    res.json({ event });
   })
   .get('/authenticate', async (req, res) => {
     let user;

--- a/routes/api.js
+++ b/routes/api.js
@@ -35,7 +35,10 @@ router
     const { uuid } = req.params;
     const { resource } = await calendlyService.getUserEventType(uuid);
 
-    const event = formatEventTypeDate(resource)
+    const eventType = formatEventTypeDate(resource)
+
+    res.json({ eventType })
+  })
   .get('/events/:uuid', isUserAuthenticated, async (req, res) => {
     const { access_token, refresh_token } = req.user;
     const { uuid } = req.params

--- a/services/calendlyService.js
+++ b/services/calendlyService.js
@@ -48,6 +48,15 @@ class CalendlyService {
     return data;
   };
 
+  getUserEventType = async (uuid) => {
+    const { data } = await this.request.get(
+      `/event_types/${uuid}`,
+      this.getRequestConfiguration()
+    );
+
+    return data;
+  };
+
   getUserScheduledEvents = async (userUri, count, pageToken) => {
     let queryParams = [
       `user=${userUri}`,

--- a/utils/index.js
+++ b/utils/index.js
@@ -26,3 +26,8 @@ exports.formatEventDateTime = (event) => ({
   start_time: formatTime(event.start_time),
   end_time: formatTime(event.end_time),
 });
+
+exports.formatEventTypeDate = (event) => ({
+  ...event,
+  last_updated: new Date(event.updated_at).toLocaleDateString()
+})

--- a/utils/index.js
+++ b/utils/index.js
@@ -27,7 +27,7 @@ exports.formatEventDateTime = (event) => ({
   end_time: formatTime(event.end_time),
 });
 
-exports.formatEventTypeDate = (event) => ({
-  ...event,
-  last_updated: new Date(event.updated_at).toLocaleDateString()
+exports.formatEventTypeDate = (eventType) => ({
+  ...eventType,
+  last_updated: new Date(eventType.updated_at).toLocaleDateString()
 })


### PR DESCRIPTION
# Changes
- added server-side API to fetch single event-type data
- created single event-type component to render single event-type data (will allow editing later)
- added single event-type path via router
- linked each event-type on dashboard to its corresponding `/event-types/{uuid}` page
- removed "hyperlink-look" of event-type name and description on dashboard
- added new method to format a `last_updated` field in single event-type resource

# Story
https://calendlyapp.atlassian.net/browse/CAL-34961