### PR TITLE
Fixes 'back' button rendering on popup

### DIFF
--- a/components/events.jsx
+++ b/components/events.jsx
@@ -191,7 +191,7 @@ export default () => {
           </button>
         </div>
       )}
-      {paginationCount > 0 && (
+      {paginationCount > 0 && !popupOpen && (
         <div className="center-align">
           <button
             className="waves-effect waves-light btn-small"


### PR DESCRIPTION
Sorry, Tristan! The last of the lightning-round of PRs today. I realize that the "Back" button in the event cancellation popup persisted on the popup, so just added in a conditional to prevent that.