### PR TITLE
Update Authentication Spec

### DIFF
--- a/components/nav.jsx
+++ b/components/nav.jsx
@@ -17,8 +17,8 @@ export default () => {
           </a>
         )}
 
+        {auth?.authenticated && (
         <ul id="nav-mobile" className="right hide-on-med-and-down">
-          {auth?.authenticated && (
             <>
               <li>
                 <a href="/">Dashboard</a>
@@ -30,8 +30,8 @@ export default () => {
                 <a href="/logout">Logout</a>
               </li>
             </>
-          )}
         </ul>
+        )}
       </div>
     </nav>
   );

--- a/components/nav.jsx
+++ b/components/nav.jsx
@@ -18,7 +18,7 @@ export default () => {
         )}
 
         {auth?.authenticated && (
-        <ul id="nav-mobile" className="right hide-on-med-and-down">
+          <ul id="nav-mobile" className="right hide-on-med-and-down">
             <>
               <li>
                 <a href="/">Dashboard</a>
@@ -30,7 +30,7 @@ export default () => {
                 <a href="/logout">Logout</a>
               </li>
             </>
-        </ul>
+          </ul>
         )}
       </div>
     </nav>

--- a/cypress/integration/authentication_spec.js
+++ b/cypress/integration/authentication_spec.js
@@ -13,7 +13,7 @@ const stubAuth = () => {
       );
     }
   );
-}
+};
 
 const stubEventTypes = () => {
   cy.intercept(
@@ -25,12 +25,12 @@ const stubEventTypes = () => {
       eventTypes: [],
     }
   );
-}
+};
 
 describe('Authentication', () => {
   it('Enables users to login and out', () => {
-    stubAuth()
-    stubEventTypes()
+    stubAuth();
+    stubEventTypes();
     cy.visit('/login');
     cy.get('nav').contains('Logout').should('not.exist');
     cy.get('.btn-large').click();
@@ -41,9 +41,9 @@ describe('Authentication', () => {
 
 describe.only('Nav bar render', () => {
   it('Should NOT be present if user has not logged in', () => {
-    cy.intercept('/api/authenticate').as('auth')
+    cy.intercept('/api/authenticate').as('auth');
     cy.visit('/login');
-    cy.wait('@auth')
+    cy.wait('@auth');
     cy.get('#nav-mobile').should('not.exist');
   });
 });

--- a/cypress/integration/authentication_spec.js
+++ b/cypress/integration/authentication_spec.js
@@ -28,22 +28,27 @@ const stubEventTypes = () => {
 };
 
 describe('Authentication', () => {
-  it('Enables users to login and out', () => {
-    stubAuth();
-    stubEventTypes();
-    cy.visit('/login');
-    cy.get('nav').contains('Logout').should('not.exist');
-    cy.get('.btn-large').click();
-    cy.get('nav').contains('Logout').click();
-    cy.get('nav').contains('Logout').should('not.exist');
-  });
-});
+  context('when user has logged in', () => {
+    beforeEach(() => {
+      stubAuth();
+      stubEventTypes();
+    });
 
-describe.only('Nav bar render', () => {
-  it('Should NOT be present if user has not logged in', () => {
-    cy.intercept('/api/authenticate').as('auth');
-    cy.visit('/login');
-    cy.wait('@auth');
-    cy.get('#nav-mobile').should('not.exist');
+    it('Enables users to login and out', () => {
+      cy.visit('/login');
+      cy.get('nav').contains('Logout').should('not.exist');
+      cy.get('.btn-large').click();
+      cy.get('nav').contains('Logout').click();
+      cy.get('nav').contains('Logout').should('not.exist');
+    });
+  });
+
+  context('when user has NOT logged in', () => {
+    it('navbar should NOT be present', () => {
+      cy.intercept('/api/authenticate').as('auth');
+      cy.visit('/login');
+      cy.wait('@auth');
+      cy.get('#nav-mobile').should('not.exist');
+    });
   });
 });

--- a/cypress/integration/authentication_spec.js
+++ b/cypress/integration/authentication_spec.js
@@ -45,9 +45,10 @@ describe('Authentication', () => {
 
   context('when user has NOT logged in', () => {
     it('navbar should NOT be present', () => {
+      cy.intercept('/login').as('login');
       cy.intercept('/api/authenticate').as('auth');
       cy.visit('/login');
-      cy.wait('@auth');
+      cy.wait(['@login', '@auth']);
       cy.get('#nav-mobile').should('not.exist');
     });
   });

--- a/cypress/integration/authentication_spec.js
+++ b/cypress/integration/authentication_spec.js
@@ -1,30 +1,36 @@
+const stubAuth = () => {
+  cy.intercept(
+    {
+      method: 'GET',
+      url: '/oauth/authorize*',
+    },
+    (req) => {
+      req.redirect(
+        `${
+          Cypress.config().baseUrl
+        }/oauth/callback?code=5BbtpL2SJIeDP4yClOJPHMJZwEDF1QkbPNaJgkTymeI`,
+        302
+      );
+    }
+  );
+}
+
+const stubEventTypes = () => {
+  cy.intercept(
+    {
+      method: 'GET',
+      url: '/api/event_types',
+    },
+    {
+      eventTypes: [],
+    }
+  );
+}
+
 describe('Authentication', () => {
   it('Enables users to login and out', () => {
-    cy.intercept(
-      {
-        method: 'GET',
-        url: '/oauth/authorize*',
-      },
-      (req) => {
-        req.redirect(
-          `${
-            Cypress.config().baseUrl
-          }/oauth/callback?code=5BbtpL2SJIeDP4yClOJPHMJZwEDF1QkbPNaJgkTymeI`,
-          302
-        );
-      }
-    );
-
-    cy.intercept(
-      {
-        method: 'GET',
-        url: '/api/event_types',
-      },
-      {
-        eventTypes: [],
-      }
-    );
-
+    stubAuth()
+    stubEventTypes()
     cy.visit('/login');
     cy.get('nav').contains('Logout').should('not.exist');
     cy.get('.btn-large').click();
@@ -35,16 +41,7 @@ describe('Authentication', () => {
 
 describe('Nav bar render', () => {
   it('Should NOT be present if user has not logged in', () => {
-    cy.intercept(
-      {
-        method: 'GET',
-        url: '/api/event_types',
-      },
-      {
-        eventTypes: [],
-      }
-    );
-
+    stubEventTypes()
     cy.visit('/login');
     cy.get('nav').should('not.exist');
   });

--- a/cypress/integration/authentication_spec.js
+++ b/cypress/integration/authentication_spec.js
@@ -39,10 +39,11 @@ describe('Authentication', () => {
   });
 });
 
-describe('Nav bar render', () => {
+describe.only('Nav bar render', () => {
   it('Should NOT be present if user has not logged in', () => {
-    stubEventTypes()
+    cy.intercept('/api/authenticate').as('auth')
     cy.visit('/login');
-    cy.get('nav').should('not.exist');
+    cy.wait('@auth')
+    cy.get('#nav-mobile').should('not.exist');
   });
 });


### PR DESCRIPTION
## Overview

These commits address an issue with the auth spec where the assertions were running before the requests finished and the page loaded. This was creating a false-positive case.

This change also consolidates some duplicated code and reorganizes the spec to provide multiple context for logged in state.

This PR is built off of the commits in PR #39 and intended to be merged after those commits are merged.

## Changes

* Fix spec giving false-positive
* Consolidate intercepts into shared functions
* Add new contexts and organize spec