### PR TITLE
[Issue-44] add pretest script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "esbuild": "esbuild components/app.jsx --bundle --outfile=public/javascripts/bundle.js",
     "start": "node app.js",
     "dev": "nf start -j Procfile.dev",
-    "test": "start-server-and-test 'NODE_ENV=test PORT=1234 npm start' 1234 'cypress open'"
+    "test": "start-server-and-test 'NODE_ENV=test PORT=1234 npm start' 1234 'cypress open'",
+    "pretest": "npm run esbuild"
   },
   "engines": {
     "node": ">=12"


### PR DESCRIPTION
This PR addresses https://github.com/calendly/buzzwordcrm/issues/44 by adding a `pretest` script to build `bundle.js` prior to running the application.