### PR TITLE
Update dashboard.jsx to correct typo.

### DIFF
--- a/components/dashboard.jsx
+++ b/components/dashboard.jsx
@@ -40,7 +40,7 @@ export default () => {
                       <PopupButton
                         url={eventType.scheduling_url}
                         rootElement={document.getElementById('root')}
-                        text="View Availbility"
+                        text="View Availability"
                         styles={{
                           borderWidth: 0,
                           backgroundColor: '#fff',


### PR DESCRIPTION
A small typo in Availability was causing Cypress tests to fail on Buzzword. This tiny PR corrects that.