### PR TITLE
Update Cypress dashboard test

### DIFF
--- a/cypress/integration/dashboard_spec.js
+++ b/cypress/integration/dashboard_spec.js
@@ -4,7 +4,6 @@ const eventTypeList = [
     "color": "#0099ff",
     "description_plain": "Introductory meeting.",
     "name": "First chat",
-    "position": 0,
     "profile": {
         "owner": "https://api.calendly.com/users/AAAAAAAAAAAAAAAA",
     },
@@ -16,7 +15,6 @@ const eventTypeList = [
   "color": "#8247f5",
   "description_plain": "Follow-up meeting.",
   "name": "Second chat",
-  "position": 1,
   "profile": {
       "owner": "https://api.calendly.com/users/AAAAAAAAAAAAAAAA",
   },
@@ -28,7 +26,6 @@ const eventTypeList = [
   "color": "#17e885",
   "description_plain": "Follow-up to the follow-up meeting",
   "name": "Third chat",
-  "position": 2,
   "profile": {
       "owner": "https://api.calendly.com/users/AAAAAAAAAAAAAAAA",
   },
@@ -39,7 +36,6 @@ const eventTypeList = [
   "active": true,
   "color": "#0099ff",
   "name": "Fourth chat",
-  "position": 3,
   "profile": {
       "owner": "https://api.calendly.com/users/AAAAAAAAAAAAAAAA",
   },
@@ -73,10 +69,11 @@ describe('Dashboard', () => {
       {
         eventTypes: eventTypeList,
       }
-    ).as('EventTypeList');
+    ).as('eventTypeList');
 
-    cy.visit('/');
+    cy.visit('/login');
     cy.contains('Log in with Calendly').click();
+    cy.wait('@eventTypeList')
     cy.get('.card-content').contains('First chat');
     cy.get('.card-content').contains('Second chat');
     cy.get('.card-content').contains('Third chat');
@@ -111,10 +108,11 @@ describe('Dashboard', () => {
       {
         eventTypes: eventTypeList,
       }
-    );
+    ).as('eventTypeList');
 
-    cy.visit('/');
+    cy.visit('/login');
     cy.contains('Log in with Calendly').click();
+    cy.wait('@eventTypeList')
     cy.get('.card-action > button').click({ multiple: true, force: true });
     cy.get('.calendly-popup-content').should('exist');
     cy.get('.calendly-close-overlay').click({ multiple: true, force: true });

--- a/cypress/integration/dashboard_spec.js
+++ b/cypress/integration/dashboard_spec.js
@@ -1,27 +1,51 @@
 const eventTypeList = [
   {
-    uri: 'https://api.calendly.com/users/AAAAAAAAAAAAAAAA',
-    name: 'First chat',
-    scheduling_url: 'https://calendly.com/acmesales',
-    description_plain: 'Introductory meeting',
+    "active": true,
+    "color": "#0099ff",
+    "description_plain": "Introductory meeting.",
+    "name": "First chat",
+    "position": 0,
+    "profile": {
+        "owner": "https://api.calendly.com/users/AAAAAAAAAAAAAAAA",
+    },
+    "scheduling_url": "https://calendly.com/acmesales",
+    "uri": "https://api.calendly.com/event_types/AAAAAAAAAAAAAAAA"
+},
+{
+  "active": true,
+  "color": "#8247f5",
+  "description_plain": "Follow-up meeting.",
+  "name": "Second chat",
+  "position": 1,
+  "profile": {
+      "owner": "https://api.calendly.com/users/AAAAAAAAAAAAAAAA",
   },
-  {
-    uri: 'https://api.calendly.com/users/BAAAAAAAAAAAAAAA',
-    name: 'Second chat',
-    scheduling_url: 'https://calendly.com/acmesales',
-    description_plain: 'Follow-up meeting',
+  "scheduling_url": "https://calendly.com/acmesales",
+  "uri": "https://api.calendly.com/event_types/BAAAAAAAAAAAAAAA"
+},
+{
+  "active": true,
+  "color": "#17e885",
+  "description_plain": "Follow-up to the follow-up meeting",
+  "name": "Third chat",
+  "position": 2,
+  "profile": {
+      "owner": "https://api.calendly.com/users/AAAAAAAAAAAAAAAA",
   },
-  {
-    uri: 'https://api.calendly.com/users/CAAAAAAAAAAAAAAA',
-    name: 'Third chat',
-    scheduling_url: 'https://calendly.com/acmesales',
-    description_plain: 'Follow-up to the follow-up meeting',
+  "scheduling_url": "https://calendly.com/acmesales",
+  "uri": "https://api.calendly.com/event_types/CAAAAAAAAAAAAAAA"
+},
+{
+  "active": true,
+  "color": "#0099ff",
+  "name": "Fourth chat",
+  "position": 3,
+  "profile": {
+      "owner": "https://api.calendly.com/users/AAAAAAAAAAAAAAAA",
   },
-  {
-    uri: 'https://api.calendly.com/users/DAAAAAAAAAAAAAAA',
-    name: 'Fourth chat',
-    scheduling_url: 'https://calendly.com/acmesales',
-  },
+  "scheduling_url": "https://calendly.com/acmesales",
+  "uri": "https://api.calendly.com/event_types/DAAAAAAAAAAAAAAA"
+},
 ];
 
 describe('Dashboard', () => {
@@ -49,10 +73,10 @@ describe('Dashboard', () => {
       {
         eventTypes: eventTypeList,
       }
-    );
+    ).as('EventTypeList');
 
     cy.visit('/');
-    cy.get('.btn-large').click();
+    cy.contains('Log in with Calendly').click();
     cy.get('.card-content').contains('First chat');
     cy.get('.card-content').contains('Second chat');
     cy.get('.card-content').contains('Third chat');
@@ -90,7 +114,7 @@ describe('Dashboard', () => {
     );
 
     cy.visit('/');
-    cy.get('.btn-large').click();
+    cy.contains('Log in with Calendly').click();
     cy.get('.card-action > button').click({ multiple: true, force: true });
     cy.get('.calendly-popup-content').should('exist');
     cy.get('.calendly-close-overlay').click({ multiple: true, force: true });


### PR DESCRIPTION
Some minor changes to the dashboard_spec Cypress test in Buzzword to reduce flakiness:

- Updated the eventTypeList const to load more consistently
- Added routes to eventTypeList to allow specific wait in tests
- Direct path to login to prevent redirect timeouts