### PR TITLE
[CAL-63775] Adds pagination for dashboard - 10 per page

### DIFF
--- a/components/dashboard.jsx
+++ b/components/dashboard.jsx
@@ -92,6 +92,8 @@ export default () => {
                     borderWidth: 0,
                     backgroundColor: '#fff',
                     cursor: 'pointer',
+                    fontWeight: 'bold',
+                    color: 'red',
                   }}
                   />
                 </div>

--- a/components/dashboard.jsx
+++ b/components/dashboard.jsx
@@ -12,20 +12,21 @@ export default () => {
   const fetchData = async () => {
     let nextPageQueryParams = '?';
 
-    if (nextPageToken === pagination.next_page_token) nextPageQueryParams += `&page_token=${nextPageToken}`;
+    if (nextPageToken === pagination.next_page_token)
+      nextPageQueryParams += `&page_token=${nextPageToken}`;
 
     if (prevPageToken === pagination.previous_page_token) {
       nextPageQueryParams = '?';
       nextPageQueryParams += `&page_token=${prevPageToken}`;
     }
 
-    const result = await fetch(
-      `/api/event_types${nextPageQueryParams}`
-    ).then((res) => res.json());
+    const result = await fetch(`/api/event_types${nextPageQueryParams}`).then(
+      (res) => res.json()
+    );
 
     setEventTypes([...result.eventTypes]);
     setPagination(result.pagination);
-  }
+  };
 
   useEffect(() => {
     fetchData();
@@ -34,73 +35,73 @@ export default () => {
   return (
     <div className="container" style={{ marginTop: '50px' }}>
       <div className="row">
-        {eventTypes.map(
-          (eventType) =>
-              <div className="col s6" key={eventType.uri}>
-                {eventType.active === true ? (
-                  <Link to={`/event_types/${eventType.uri.split('/')[4]}`}>
-                    <div className="card">
-                      <div
-                      style={{
-                        backgroundColor: eventType.color,
-                        height: 50,
-                        width: '100%',
-                      }}
-                      ></div>
-                      <div className="card-content" style={{ color: 'black' }}>
-                        <p>{eventType.name}</p>
-                        <p style={{ fontSize: 'small' }}>
-                          Description:{' '}
-                          {eventType.description_plain || 'No description'}
-                        </p>
-                      </div>
-                      <div className="card-action">
-                        <PopupButton
-                          url={eventType.scheduling_url}
-                          rootElement={document.getElementById('root')}
-                          text="View Availability"
-                          styles={{
-                            borderWidth: 0,
-                            backgroundColor: '#fff',
-                            cursor: 'pointer',
-                          }}
-                        />
-                      </div>
-                    </div>
-                  </Link> ) : (
+        {eventTypes.map((eventType) => (
+          <div className="col s6" key={eventType.uri}>
+            {eventType.active === true ? (
+              <Link to={`/event_types/${eventType.uri.split('/')[4]}`}>
                 <div className="card">
                   <div
-                      style={{
-                        backgroundColor: eventType.color,
-                        height: 50,
-                        width: '100%',
-                      }}
+                    style={{
+                      backgroundColor: eventType.color,
+                      height: 50,
+                      width: '100%',
+                    }}
                   ></div>
                   <div className="card-content" style={{ color: 'black' }}>
                     <p>{eventType.name}</p>
-                      <p style={{ fontSize: 'small' }}>
-                        Description:{' '}
-                        {eventType.description_plain || 'No description'}
-                      </p>
+                    <p style={{ fontSize: 'small' }}>
+                      Description:{' '}
+                      {eventType.description_plain || 'No description'}
+                    </p>
                   </div>
+                  <div className="card-action">
+                    <PopupButton
+                      url={eventType.scheduling_url}
+                      rootElement={document.getElementById('root')}
+                      text="View Availability"
+                      styles={{
+                        borderWidth: 0,
+                        backgroundColor: '#fff',
+                        cursor: 'pointer',
+                      }}
+                    />
+                  </div>
+                </div>
+              </Link>
+            ) : (
+              <div className="card">
+                <div
+                  style={{
+                    backgroundColor: eventType.color,
+                    height: 50,
+                    width: '100%',
+                  }}
+                ></div>
+                <div className="card-content" style={{ color: 'black' }}>
+                  <p>{eventType.name}</p>
+                  <p style={{ fontSize: 'small' }}>
+                    Description:{' '}
+                    {eventType.description_plain || 'No description'}
+                  </p>
+                </div>
                 <div className="card-action">
                   <PopupButton
-                  url={eventType.scheduling_url}
-                  rootElement={document.getElementById('root')}
-                  text="INACTIVE EVENT TYPE"
-                  styles={{
-                    borderWidth: 0,
-                    backgroundColor: '#fff',
-                    cursor: 'pointer',
-                    fontWeight: 'bold',
-                    color: 'red',
-                  }}
+                    url={eventType.scheduling_url}
+                    rootElement={document.getElementById('root')}
+                    text="INACTIVE EVENT TYPE"
+                    styles={{
+                      borderWidth: 0,
+                      backgroundColor: '#fff',
+                      cursor: 'pointer',
+                      fontWeight: 'bold',
+                      color: 'red',
+                    }}
                   />
                 </div>
-              </div>)
-            }
+              </div>
+            )}
           </div>
-        )}
+        ))}
       </div>
       {pagination?.next_page && (
         <div className="next-back-btns">

--- a/components/dashboard.jsx
+++ b/components/dashboard.jsx
@@ -4,23 +4,40 @@ import { Link } from 'react-router-dom';
 
 export default () => {
   const [eventTypes, setEventTypes] = useState([]);
+  const [pagination, setPagination] = useState({});
+  const [nextPageToken, setNextPageToken] = useState(null);
+  const [prevPageToken, setPrevPageToken] = useState(null);
+  const [paginationCount, setPaginationCount] = useState(0);
+
+  const fetchData = async () => {
+    let nextPageQueryParams = '?';
+
+    if (nextPageToken === pagination.next_page_token) nextPageQueryParams += `&page_token=${nextPageToken}`;
+
+    if (prevPageToken === pagination.previous_page_token) {
+      nextPageQueryParams = '?';
+      nextPageQueryParams += `&page_token=${prevPageToken}`;
+    }
+
+    const result = await fetch(
+      `/api/event_types${nextPageQueryParams}`
+    ).then((res) => res.json());
+
+    setEventTypes([...result.eventTypes]);
+    setPagination(result.pagination);
+  }
 
   useEffect(() => {
-    fetch('/api/event_types')
-      .then((res) => res.json())
-      .then((result) => {
-        setEventTypes(result.eventTypes);
-      });
-  }, []);
+    fetchData();
+  }, [nextPageToken, prevPageToken]);
 
   return (
     <div className="container" style={{ marginTop: '50px' }}>
       <div className="row">
         {eventTypes.map(
           (eventType) =>
-            eventType.active === true && (
               <div className="col s6" key={eventType.uri}>
-                <Link to={`/event_types/${eventType.uri.split('/')[4]}`}>
+                <Link to={eventType.active === true ? `/event_types/${eventType.uri.split('/')[4]}`: ''}>
                   <div className="card">
                     <div
                       style={{
@@ -36,8 +53,8 @@ export default () => {
                         {eventType.description_plain || 'No description'}
                       </p>
                     </div>
-                    <div className="card-action">
-                      <PopupButton
+                    {eventType.active === true ? <div className="card-action">
+                       <PopupButton
                         url={eventType.scheduling_url}
                         rootElement={document.getElementById('root')}
                         text="View Availability"
@@ -47,13 +64,39 @@ export default () => {
                           cursor: 'pointer',
                         }}
                       />
-                    </div>
+                    </div> : 'INACTIVE EVENT TYPE'}
                   </div>
                 </Link>
               </div>
-            )
         )}
       </div>
+      {pagination?.next_page && (
+        <div className="next-back-btns">
+          <button
+            className="waves-effect waves-light btn-small"
+            onClick={() => {
+              setPaginationCount(paginationCount + 1);
+              setNextPageToken(pagination.next_page_token);
+              setPrevPageToken(false);
+            }}
+          >
+            Show Next
+          </button>
+        </div>
+      )}
+      {paginationCount > 0 && (
+        <div className="next-back-btns">
+          <button
+            className="waves-effect waves-light btn-small"
+            onClick={() => {
+              setPaginationCount(paginationCount - 1);
+              setPrevPageToken(pagination.previous_page_token);
+            }}
+          >
+            Back
+          </button>
+        </div>
+      )}
     </div>
   );
 };

--- a/components/dashboard.jsx
+++ b/components/dashboard.jsx
@@ -37,37 +37,67 @@ export default () => {
         {eventTypes.map(
           (eventType) =>
               <div className="col s6" key={eventType.uri}>
-                <Link to={eventType.active === true ? `/event_types/${eventType.uri.split('/')[4]}`: ''}>
-                  <div className="card">
-                    <div
+                {eventType.active === true ? (
+                  <Link to={`/event_types/${eventType.uri.split('/')[4]}`}>
+                    <div className="card">
+                      <div
                       style={{
                         backgroundColor: eventType.color,
                         height: 50,
                         width: '100%',
                       }}
-                    ></div>
-                    <div className="card-content" style={{ color: 'black' }}>
-                      <p>{eventType.name}</p>
+                      ></div>
+                      <div className="card-content" style={{ color: 'black' }}>
+                        <p>{eventType.name}</p>
+                        <p style={{ fontSize: 'small' }}>
+                          Description:{' '}
+                          {eventType.description_plain || 'No description'}
+                        </p>
+                      </div>
+                      <div className="card-action">
+                        <PopupButton
+                          url={eventType.scheduling_url}
+                          rootElement={document.getElementById('root')}
+                          text="View Availability"
+                          styles={{
+                            borderWidth: 0,
+                            backgroundColor: '#fff',
+                            cursor: 'pointer',
+                          }}
+                        />
+                      </div>
+                    </div>
+                  </Link> ) : (
+                <div className="card">
+                  <div
+                      style={{
+                        backgroundColor: eventType.color,
+                        height: 50,
+                        width: '100%',
+                      }}
+                  ></div>
+                  <div className="card-content" style={{ color: 'black' }}>
+                    <p>{eventType.name}</p>
                       <p style={{ fontSize: 'small' }}>
                         Description:{' '}
                         {eventType.description_plain || 'No description'}
                       </p>
-                    </div>
-                    {eventType.active === true ? <div className="card-action">
-                       <PopupButton
-                        url={eventType.scheduling_url}
-                        rootElement={document.getElementById('root')}
-                        text="View Availability"
-                        styles={{
-                          borderWidth: 0,
-                          backgroundColor: '#fff',
-                          cursor: 'pointer',
-                        }}
-                      />
-                    </div> : 'INACTIVE EVENT TYPE'}
                   </div>
-                </Link>
-              </div>
+                <div className="card-action">
+                  <PopupButton
+                  url={eventType.scheduling_url}
+                  rootElement={document.getElementById('root')}
+                  text="INACTIVE EVENT TYPE"
+                  styles={{
+                    borderWidth: 0,
+                    backgroundColor: '#fff',
+                    cursor: 'pointer',
+                  }}
+                  />
+                </div>
+              </div>)
+            }
+          </div>
         )}
       </div>
       {pagination?.next_page && (

--- a/cypress/integration/dashboard_spec.js
+++ b/cypress/integration/dashboard_spec.js
@@ -20,7 +20,7 @@ describe('Dashboard', () => {
     cy.intercept(
       {
         method: 'GET',
-        url: '/api/event_types',
+        url: '/api/event_types*',
       },
       {
         eventTypes: eventTypeList,
@@ -59,7 +59,7 @@ describe('Dashboard', () => {
     cy.intercept(
       {
         method: 'GET',
-        url: '/api/event_types',
+        url: '/api/event_types*',
       },
       {
         eventTypes: eventTypeList,

--- a/routes/api.js
+++ b/routes/api.js
@@ -35,13 +35,18 @@ router
       next(error);
     }
   })
-  .get('/event_types', isUserAuthenticated, async (req, res) => {
-    const { access_token, refresh_token, calendly_uid } = req.user;
-    const calendlyService = new CalendlyService(access_token, refresh_token);
-    const { collection: eventTypes, pagination } =
-      await calendlyService.getUserEventTypes(calendly_uid);
+  .get('/event_types', isUserAuthenticated, async (req, res, next) => {
+    try {
+      const { access_token, refresh_token, calendly_uid } = req.user;
+      const { count, page_token } = req.query;
 
-    res.json({ eventTypes, pagination });
+      const calendlyService = new CalendlyService(access_token, refresh_token);
+      const { collection: eventTypes, pagination } =
+      await calendlyService.getUserEventTypes(calendly_uid, count, page_token);
+      res.json({ eventTypes, pagination });
+    } catch (error) {
+      next(error)
+    }
   })
   .get('/event_types/:uuid', isUserAuthenticated, async (req, res) => {
     const { access_token, refresh_token } = req.user;

--- a/services/calendlyService.js
+++ b/services/calendlyService.js
@@ -39,11 +39,14 @@ class CalendlyService {
     return data;
   };
 
-  getUserEventTypes = async (userUri) => {
-    const { data } = await this.request.get(
-      `/event_types?user=${userUri}`,
-      this.requestConfiguration()
-    );
+  getUserEventTypes = async (userUri, count, pageToken) => {
+    let queryParams = [`count=${count || 10}`].join('&');
+
+    if (pageToken) queryParams += `&page_token=${pageToken}`;
+
+    const url = `/event_types?${queryParams}&user=${userUri}`;
+
+    const { data } =  await this.request.get(url, this.requestConfiguration());
 
     return data;
   };


### PR DESCRIPTION
## Changes
* updated `dashboard` component to handle pagination @ 10 per page
* updated `/event_types` route to incorporate pagination
* updated services to call `GET` `/event_types` at 10 rows per page

## Story
https://calendlyapp.atlassian.net/browse/CAL-63775

## QA
- [x] Run `npm run dev`, and be sure to test that all (ie, both active and inactive) ETs are displayed on the dashboard, and pagination works @ 10 results per page

## Quick Reference
- [Delivery Process](https://calendlyapp.atlassian.net/wiki/spaces/EN/pages/385809/Delivery+Process)