### PR TITLE
[CAL-66127] Makes use of added /users/me endpoint to resolve 500s

### DIFF
--- a/components/userBusyTimes.jsx
+++ b/components/userBusyTimes.jsx
@@ -6,7 +6,7 @@ import moment from 'moment';
 
 export default () => {
   const location = useLocation().search;
-  const user = new URLSearchParams(location).get('user');
+  const [user, setUser] = useState();
   const [busyTimes, setBusyTimes] = useState([]);
   const [date, setDate] = useState('');
   const [queryParams, setQueryParams] = useState();
@@ -15,7 +15,6 @@ export default () => {
   const [finalDateMillisec, setFinalDateMillisec] = useState();
   const [schedule, setSchedule] = useState([]);
   const [endTime, setEndTime] = useState();
-  const [availUser, setAvailUser] = useState();
   const [monTotalBusy, setMonTotalBusy] = useState(0);
   const [tuesTotalBusy, setTuesTotalBusy] = useState(0);
   const [wedTotalBusy, setWedTotalBusy] = useState(0);
@@ -30,7 +29,6 @@ export default () => {
   const [friTotalAvail, setFriTotalAvail] = useState(0);
   const [satTotalAvail, setSatTotalAvail] = useState(0);
   const [sunTotalAvail, setSunTotalAvail] = useState(0);
-  const [namedUser, setNamedUser] = useState();
 
   const busyTimesObj = {};
 
@@ -75,19 +73,28 @@ export default () => {
     sunday: [sunTotalBusy, sunTotalAvail],
   };
 
+  const fetchUser = async () => {
+    const result = await fetch('/api/users/me').then((res) =>
+      res.json()
+    );
+    setUser(result.resource);
+  };
+  
   const fetchBusyTimesData = async () => {
-    const result = await fetch(
-      `/api/user_busy_times?user=${user}${queryParams}`
+    if (user) {
+      const result = await fetch(
+      `/api/user_busy_times?user=${user.uri}${queryParams}`
     ).then((res) => res.json());
 
     setBusyTimes(result.busyTimes);
+    }
   };
 
   const fetchUserAvailabilityData = async () => {
     //This is to avoid nested mapping through the schedules array at first render
-    setAvailUser(new URLSearchParams(location).get('user'));
-    const result = await fetch(
-      `/api/user_availability_schedules?user=${availUser}`
+    if (user) {
+      const result = await fetch(
+      `/api/user_availability_schedules?user=${user.uri}`
     ).then((res) => res.json());
 
     let countDays = 0;
@@ -124,14 +131,10 @@ export default () => {
     }
 
     setSchedule(result.availabilitySchedules);
-  };
+    }
+    
 
-  const fetchUser = async () => {
-    const result = await fetch(`/api/users/${user.split('/')[4]}`).then((res) =>
-      res.json()
-    );
-
-    setNamedUser(result.resource);
+    
   };
 
   const getDayOfWeek = (date) => {
@@ -396,7 +399,7 @@ export default () => {
 
   return (
     <div className="event-avail-selection-box">
-      <h5>{`${namedUser?.name.split(' ')[0] || ''}'s Availability`}</h5>
+      <h5>{`${user?.name.split(' ')[0] || ''}'s Availability`}</h5>
       <h6 className="event-avail-header">
         Choose a start DATE/TIME below, then click SUBMIT
       </h6>
@@ -553,10 +556,10 @@ export default () => {
             </table>
             <div style={{ fontSize: 'xx-large' }}>
               <PopupButton
-                url={namedUser?.scheduling_url}
+                url={user?.scheduling_url}
                 rootElement={document.getElementById('root')}
                 text={`Book a meeting with ${
-                  namedUser?.name.split(' ')[0] || ''
+                  user?.name.split(' ')[0] || ''
                 }`}
                 styles={{
                   backgroundColor: 'rgb(238,110,115,0.1)',

--- a/components/userBusyTimes.jsx
+++ b/components/userBusyTimes.jsx
@@ -5,7 +5,6 @@ import { PopupButton } from 'react-calendly';
 import moment from 'moment';
 
 export default () => {
-  const location = useLocation().search;
   const [user, setUser] = useState();
   const [busyTimes, setBusyTimes] = useState([]);
   const [date, setDate] = useState('');
@@ -91,7 +90,6 @@ export default () => {
   };
 
   const fetchUserAvailabilityData = async () => {
-    //This is to avoid nested mapping through the schedules array at first render
     if (user) {
       const result = await fetch(
       `/api/user_availability_schedules?user=${user.uri}`


### PR DESCRIPTION
## Changes
* Added `/users/me` call to `components/userBusyTimes.jsx` to improve setting of `user`
* Added conditional to ensure that `user` is defined when making respective API calls
* Got rid of, now unnecessary, `availUser` and `namedUser` variables/Hooks

## Story
https://calendlyapp.atlassian.net/browse/CAL-66127

## QA
- [x] Ensure that there are no `500`'s at availability page (ie, `/user_busy_times` page)
- [x] Ensure that data renders appropriately (note that there's a [ticket](https://calendlyapp.atlassian.net/browse/CAL-63784) to improve this rendering)

## Quick Reference
- [Delivery Process](https://calendlyapp.atlassian.net/wiki/spaces/EN/pages/385809/Delivery+Process)