### PR TITLE
Fix 500 error on event_type_available_times, user_busy_times endpoints + user busy times component css fix

### DIFF
--- a/cypress/integration/event_type_details_spec.js
+++ b/cypress/integration/event_type_details_spec.js
@@ -20,7 +20,7 @@ describe('Event Type Details', () => {
     cy.intercept(
       {
         method: 'GET',
-        url: '/api/event_types',
+        url: '/api/event_types?',
       },
       {
         eventTypes: eventTypeList,

--- a/cypress/integration/invitee_details_spec.js
+++ b/cypress/integration/invitee_details_spec.js
@@ -19,6 +19,20 @@ const scheduledEvents = [
   },
 ];
 
+const userResource = {
+  "avatar_url": null,
+  "created_at": "2019-10-17T13:23:46.287139Z",
+  "current_organization": "https://api.calendly.com/organizations/ORGANIZATION_UUID",
+  "email": "mail@org.com",
+  "name": "John Doe",
+  "resource_type": "User",
+  "scheduling_url": "https://calendly.com/user",
+  "slug": "userslug",
+  "timezone": "America/New_York",
+  "updated_at": "2019-10-17T13:23:46.287139Z",
+  "uri": "https://api.calendly.com/users/USER_UUID",
+};
+
 const eventInvitees = [
   {
     event: 'https://api.calendly.com/scheduled_events/GFGBDCAADAEDCRZ2',
@@ -70,6 +84,14 @@ const eventInvitees = [
   },
 ];
 
+const eventInviteesPagination = {
+    "count": 20,
+    "next_page": "https://calendly.com/scheduled_events/AAAAAAAAAAAAAAAA/invitees?count=1&page_token=sNjq4TvMDfUHEl7zHRR0k0E1PCEJWvdi",
+    "previous_page": "https://calendly.com/scheduled_events/AAAAAAAAAAAAAAAA/invitees?count=1&page_token=VJs2rfDYeY8ahZpq0QI1O114LJkNjd7H",
+    "next_page_token": "sNjq4TvMDfUHEl7zHRR0k0E1PCEJWvdi",
+    "previous_page_token": "VJs2rfDYeY8ahZpq0QI1O114LJkNjd7H"
+}
+
 const noShow = {
   uri: 'https://api.calendly.com/invitee_no_shows/639fa667-4c1b-4b20-93b5-1b1969d67dc7',
   invitee:
@@ -97,7 +119,7 @@ describe('Scheduled Event Invitee Details', () => {
     cy.intercept(
       {
         method: 'GET',
-        url: '/api/event_types',
+        url: '/api/event_types?',
       },
       {
         eventTypes: [],
@@ -112,7 +134,7 @@ describe('Scheduled Event Invitee Details', () => {
       {
         events: scheduledEvents,
       }
-    );
+    ).as('scheduledEvents');
 
     cy.intercept(
       {
@@ -131,15 +153,27 @@ describe('Scheduled Event Invitee Details', () => {
       },
       {
         invitees: eventInvitees,
+        pagination: eventInviteesPagination,
       }
     );
+
+    cy.intercept(
+      {
+        method: 'GET',
+        url: '/api/users/me',
+      },
+      {
+          resource: userResource,
+      }
+    )
 
     cy.visit('/login');
     cy.get('.btn-large').click();
     cy.get('nav').contains('Events').click();
+    cy.wait('@scheduledEvents');
     cy.get('td').eq(0).contains('First chat').click();
     cy.get('.scheduled-event-header').contains('First chat');
-    cy.get('.invitee-details-link')
+    cy.get('.details-link')
       .contains('Click here for invitee details')
       .click();
     cy.get('tbody').contains('John Doe');
@@ -174,6 +208,7 @@ describe('Scheduled Event Invitee Details', () => {
       },
       {
         invitees: eventInvitees,
+        pagination: eventInviteesPagination,
       }
     );
 

--- a/cypress/integration/scheduled_events_spec.js
+++ b/cypress/integration/scheduled_events_spec.js
@@ -1,3 +1,13 @@
+const dateInFuture = new Date(new Date().setFullYear(new Date().getFullYear() + 30));
+const dateInFutureDateFormat = Intl.DateTimeFormat(undefined,{ year: "numeric",
+  month: "numeric",
+  day: "numeric",
+  timeZone: "UTC"}).format(dateInFuture)
+const dateInFutureTimeFormat = Intl.DateTimeFormat(undefined,{ hour: "numeric",
+  minute: "numeric",
+  second: "numeric",
+  timeZone: "UTC"}).format(dateInFuture)
+
 const scheduledEvents = [
   {
     uri: 'https://api.calendly.com/scheduled_events/GBGBDCAADAEDCRZ2',
@@ -29,13 +39,31 @@ const scheduledEvents = [
   {
     uri: 'https://api.calendly.com/scheduled_events/GFBGBDCAADAEDCRZ4',
     name: 'Third chat',
-    date: '11/11/2022',
-    start_time: '2022-11-11T20:00:00.000Z',
-    start_time_formatted: '03:00 PM',
+    date: dateInFutureDateFormat,
+    start_time: dateInFuture.toISOString(),
+    start_time_formatted: dateInFutureTimeFormat,
     end_time_formatted: '03:30 PM',
     status: 'active',
   },
 ];
+
+const userResource = {
+  "avatar_url": null,
+  "created_at": "2019-10-17T13:23:46.287139Z",
+  "current_organization": "https://api.calendly.com/organizations/ORGANIZATION_UUID",
+  "email": "mail@org.com",
+  "name": "John Doe",
+  "resource_type": "User",
+  "scheduling_url": "https://calendly.com/user",
+  "slug": "userslug",
+  "timezone": "America/New_York",
+  "updated_at": "2019-10-17T13:23:46.287139Z",
+  "uri": "https://api.calendly.com/users/USER_UUID",
+};
+
+const scheduledEventsPagination = {
+  "count": 0,
+}
 
 describe('Scheduled Events', () => {
   it('Should render a table of all scheduled events, allowing filtering by all, active, and canceled events', () => {
@@ -57,7 +85,7 @@ describe('Scheduled Events', () => {
     cy.intercept(
       {
         method: 'GET',
-        url: '/api/event_types',
+        url: '/api/event_types?',
       },
       {
         eventTypes: [],
@@ -71,6 +99,7 @@ describe('Scheduled Events', () => {
       },
       {
         events: scheduledEvents,
+        pagination: scheduledEventsPagination
       }
     );
 
@@ -81,6 +110,7 @@ describe('Scheduled Events', () => {
       },
       {
         events: [scheduledEvents[0], scheduledEvents[2]],
+        pagination: scheduledEventsPagination
       }
     );
 
@@ -91,8 +121,19 @@ describe('Scheduled Events', () => {
       },
       {
         events: [scheduledEvents[1]],
+        pagination: scheduledEventsPagination
       }
     );
+
+    cy.intercept(
+      {
+        method: 'GET',
+        url: '/api/users/me',
+      },
+      {
+          resource: userResource,
+      }
+    )
 
     cy.visit('/login');
     cy.get('.btn-large').click();
@@ -108,8 +149,8 @@ describe('Scheduled Events', () => {
     cy.get('td').eq(8).should('have.text', '03:30 PM');
     cy.get('td').eq(9).should('have.text', 'CANCELED');
     cy.get('td').eq(10).should('have.text', 'Third chat');
-    cy.get('td').eq(11).should('have.text', '11/11/2022');
-    cy.get('td').eq(12).should('have.text', '03:00 PM');
+    cy.get('td').eq(11).should('have.text', dateInFutureDateFormat);
+    cy.get('td').eq(12).should('have.text', dateInFutureTimeFormat);
     cy.get('td').eq(13).should('have.text', '03:30 PM');
     cy.get('td').eq(14).should('have.text', 'ACTIVE');
     cy.get('.css-4xgw5l-IndicatorsContainer2').click();
@@ -120,8 +161,8 @@ describe('Scheduled Events', () => {
     cy.get('td').eq(3).should('have.text', '05:00 PM');
     cy.get('td').eq(4).should('have.text', 'ACTIVE');
     cy.get('td').eq(5).should('have.text', 'Third chat');
-    cy.get('td').eq(6).should('have.text', '11/11/2022');
-    cy.get('td').eq(7).should('have.text', '03:00 PM');
+    cy.get('td').eq(6).should('have.text', dateInFutureDateFormat);
+    cy.get('td').eq(7).should('have.text', dateInFutureTimeFormat);
     cy.get('td').eq(8).should('have.text', '03:30 PM');
     cy.get('td').eq(9).should('have.text', 'ACTIVE');
     cy.get('.css-4xgw5l-IndicatorsContainer2').click();
@@ -144,8 +185,8 @@ describe('Scheduled Events', () => {
     cy.get('td').eq(8).should('have.text', '03:30 PM');
     cy.get('td').eq(9).should('have.text', 'CANCELED');
     cy.get('td').eq(10).should('have.text', 'Third chat');
-    cy.get('td').eq(11).should('have.text', '11/11/2022');
-    cy.get('td').eq(12).should('have.text', '03:00 PM');
+    cy.get('td').eq(11).should('have.text', dateInFutureDateFormat);
+    cy.get('td').eq(12).should('have.text', dateInFutureTimeFormat);
     cy.get('td').eq(13).should('have.text', '03:30 PM');
     cy.get('td').eq(14).should('have.text', 'ACTIVE');
   });
@@ -180,7 +221,7 @@ describe('Scheduled Events', () => {
     cy.get('.popup-box').contains('Yes, cancel').click({ force: true });
     cy.on('window:alert', (alertMessage) => {
       expect(alertMessage).to.equal(
-        'You have successfully canceled the following event: "Third chat" on 11/11/2022 at 03:00 PM!'
+        `You have successfully canceled the following event: "Third chat" on ${dateInFutureDateFormat} at ${dateInFutureTimeFormat}!`
       );
     });
   });

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -64,9 +64,7 @@ button {
     margin: auto;
     padding-top: 0.2em;
     padding-bottom: 5em;
-    position: center;
     text-align: center;
-    width: 100em;
 }
 
 .event-type-and-user-availability {

--- a/routes/api.js
+++ b/routes/api.js
@@ -6,6 +6,7 @@ const {
   formatEventTypeDate,
   formatInviteeDateTime,
   formatEventTypeAvailTime,
+  formatISOExtended,
 } = require('../utils');
 const router = express.Router();
 const User = require('../models/userModel');
@@ -102,8 +103,8 @@ router
         const { event_type, end_time, start_time } = req.query;
 
         const { collection } = await calendlyService.getUserEventTypeAvailTimes(
-          event_type,
-          start_time,
+          formatISOExtended(event_type),
+          formatISOExtended(start_time),
           end_time,
           calendly_uid
         );
@@ -125,8 +126,8 @@ router
 
       const { collection } = await calendlyService.getUserBusyTimes(
         user,
-        start_time,
-        end_time,
+        formatISOExtended(start_time),
+        formatISOExtended(end_time),
         calendly_uid
       );
 

--- a/utils/index.js
+++ b/utils/index.js
@@ -29,6 +29,26 @@ exports.formatEventDateTime = (event) => ({
   end_time_formatted: formatTime(event.end_time),
 });
 
+exports.formatISOExtended = (dateObj) => {
+  // Get individual date components
+  const date = new Date(dateObj);
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  const hours = String(date.getUTCHours()).padStart(2, '0');
+  const minutes = String(date.getUTCMinutes()).padStart(2, '0');
+  const seconds = String(date.getUTCSeconds()).padStart(2, '0');
+
+  // Get milliseconds and extend to six fractional digits
+  const milliseconds = String(date.getUTCMilliseconds()).padStart(3, '0');
+  const extendedFractional = milliseconds + '000'; // Pad to six digits
+
+  // Construct the extended ISO string
+  const extendedISO = `${year}-${month}-${day}T${hours}:${minutes}:${seconds}.${extendedFractional}Z`;
+
+  return extendedISO;
+}
+
 exports.formatEventTypeDate = (eventType) => ({
   ...eventType,
   last_updated: new Date(eventType.updated_at).toLocaleDateString(),


### PR DESCRIPTION
# Fix 500 error on `event_type_available_times` and `user_busy_times` + user busy times component fix

BE: `event_type_available_times` and `user_busy_times` endpoints are expecting ISO format with 6 milliseconds fragment decimals: e.g.: `YYYY-MM-DDTHH:mm:ss.ssssssZ` ([docs](https://developer.calendly.com/api-docs/6a1be82aef359-list-event-type-available-times)) but current code is using `toISOString()` for date conversion, which by default brings 3 milliseconds fragments decimals (YYYY-MM-DDTHH:mm:ss.sssZ), throwing an 500 validation error.

FE: User Busy times component presents an error on the main class: 
## Before
<img width="1114" alt="Screenshot 2024-07-02 at 10 59 26 PM" src="https://github.com/calendly/buzzwordcrm/assets/2389110/1b465ced-c931-42af-85e8-34f2ed44f044">
## After
<img width="1108" alt="Screenshot 2024-07-02 at 10 59 48 PM" src="https://github.com/calendly/buzzwordcrm/assets/2389110/a141fafa-81f7-40f0-9cb7-798137a5b6f1">

